### PR TITLE
Use python3 packages and remove drop output module

### DIFF
--- a/alpine/Dockerfile/Dockerfile
+++ b/alpine/Dockerfile/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine
 ## Install Suricata as describe here https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Distributions_Containing_Suricata Repository : https://pkgs.alpinelinux.org/package/edge/community/x86/suricata
 RUN apk add suricata --no-cache
 # Install Suricata-update utility https://github.com/OISF/suricata-update
-RUN apk add python py-pip
+RUN apk add python3 py3-pip
 RUN pip install suricata-update
 COPY suricata-update.sh /etc/suricata/suricata-update.sh
 # COPY file needed for the Suricata efficiency

--- a/alpine/Dockerfile/suricata.yaml
+++ b/alpine/Dockerfile/suricata.yaml
@@ -363,13 +363,6 @@ outputs:
       #level: Info ## possible levels: Emergency, Alert, Critical,
                    ## Error, Warning, Notice, Info, Debug
 
-  # a line based information for dropped packets in IPS mode
-  - drop:
-      enabled: yes
-      filename: drop.log
-      append: yes
-      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
-
   # output module to store extracted files to disk
   #
   # The files are stored to the log-dir in a format "file.<id>" where <id> is


### PR DESCRIPTION
The installation fails at the moment because the python package names are not valid anymore.